### PR TITLE
Initial OPENSSL.md and README.md files

### DIFF
--- a/OPENSSL.md
+++ b/OPENSSL.md
@@ -1,0 +1,77 @@
+### Building OpenSSL for shell bundles
+
+To build OpenSSL for shell bundles, we require building:
+
+- OpenSSL 0.9.8
+- OpenSSL 1.0.0
+
+If you have write access to the MSFTOSSMgmt repositories, then you can
+access [this repository] (https://github.com/MSFTOSSMgmt/openssl) for
+easy access to these two versions of SSL.
+
+If you do not have access to this repository, you can get the source code
+from the [public repository] (https://github.com/openssl/openssl). Note
+that we are after initial releases of OpenSSL 0.9.8 and OpenSSL 1.0.0
+(no patches after those two versions).
+
+#### Building SSL 0.9.8
+
+Untar your distribution file, if necessary, and go into the base
+directory of OpenSSL 0.9.8 with a command like:<br>```cd openssl-0.9.8```
+
+Configure the software based on your build system:
+
+- On a CentOS 6.x 64 bit OS, use ```./config no-asm -fPIC --prefix=/usr/local_ssl_0.9.8 shared```
+
+- For all other platforms, use ```./config --prefix=/usr/local_ssl_0.9.8 shared```
+
+After OpenSSL 0.9.8 is properly configured, use the standard mantra:
+
+```
+make
+make test
+sudo make install
+```
+
+Note that its normal to sometimes get unit test errors for SSL 0.9.8.
+If that happens, just proceed to 'sudo make install'.
+
+#### Building SSL 1.0.0
+
+Untar your distribution file, if necessary, and go into the base
+directory of OpenSSL 1.0.0 with a command like:<br>```cd openssl-1.0.0```
+
+To configure and build SSL 1.0.0, use the following commands:
+
+```shell
+./config --prefix=/usr/local_ssl_1.0.0 shared -no-ssl2 -no-ec -no-ec2m -no-ecdh
+make depend
+make
+make test
+sudo make install_sw
+```
+
+Unlike SSL 0.9.8, we've never seen unit test failures for SSL 1.0.0.
+
+Notes for SSL configuration:
+
+- Note: https://stackoverflow.com/questions/8206546/undefined-symbol-sslv2-method discusses why the -no-ssl2 qualifier is now required for compatibility with newer Ubuntu systems, depending on APIs utilized by the SSL client.
+
+- https://stackoverflow.com/questions/22311699/trouble-with-openssl-on-rhel-6-3-and-all-ruby-installers describes why we need to specify the -no-ec2m flag.
+
+### Closing notes
+
+We need these installed ONLY on ULinux build systems
+(i.e. CentOS 32-bit and 64-bit, depending on the product(s) involved).
+No other systems need these kits.
+
+Note that the ./config line utilize the --prefix option. The directory
+paths for the prefix (```/usr/local_ssl_0.9.8``` and
+```/usr/local_ssl_1.0.0```) are hard-coded in our make process.  You can't
+change that without careful consideration, as it would impact the build
+procedures for numerous projects.
+
+Finally, note that these bits are both installed <b>regardless</b> of the
+version of SSL installed on the system. Furthermore, nothing (other than
+our kit) links against these. No system software uses the SSL versions
+in these locations.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,129 @@
+### To set up machine to build OMS
+
+There are two ways to build OMS.
+
+1. As an RPM or DEB package that can be installed on the local system,
+assuming all dependencies are met (most easily met if a shell bundle
+was previously installed to "seed" the system), or
+2. As a shell bundle.
+
+Building a shell bundle is a superset of of setting up a system to
+build a local RPM, so we will cover that first.
+
+#### To set up system to build a native package
+
+Note that it's very nice to be able to use the [updatedns]
+(https://github.com/jeffaco/msft-updatedns) project to
+use host names rather than IP numbers. On CentOS systems, this requires
+the bind-utils package (updatedns requires the 'dig' program). The
+bind-utils package isn't otherwise necessary.
+
+- On CentOS 7.x
+```
+ sudo yum install git bind-utils ruby bison gcc-c++ rpm-devel pam-devel openssl-devel rpm-build
+```
+- On Ubuntu 14.04
+```
+ sudo apt-get install git pkg-config make ruby bison g++ rpm librpm-dev libpam0g-dev libssl-dev
+```
+
+- Notes on other platforms
+
+ When building a machine for ULINUX builds (such as CentOS 5.x), we suggest
+ using the O/S distribution CD to install the packages. It's not as easy,
+ but that's the only way to guarentee that packages aren't updated such that
+ generated binaries are not backwards compatible. (See notes on building a
+ shell bundle, elsewhere in this document.)
+
+ Also note that since you won't use 'yum', you must also handle the dependent
+ packages manually (keep adding lines to the 'rpm install' command line until
+ all dependencies are satisfied).
+
+ Similar methods would be utilized if building a Redhat system that is not
+ registered for use for up2date.
+
+##### Notes on sudoers configuragion
+
+Two changes should be made to your sudoers configuration for omsagent to
+build properly:
+
+1. Configure sudoers to not require a TTY.
+
+ Some platforms require a TTY be default, and this can be problematic for
+ background builds. If you have a line like:
+
+ ```Defaults    requiretty```
+
+ then comment it out (like this):
+
+ ```#Defaults    requiretty```
+
+2. Configure your account to not require a password by adding the NOPASSWD:
+qualifier to the appropriate line that affects your account. After the correct
+changes are applied to /etc/sudoers, test under your personal account with the
+following sequence:
+
+ ```shell
+ sudo -k
+ sudo ls
+ ```
+
+ If there is no password prompt, then /etc/sudoers was correctly modified.
+
+#### To set up system to build a shell bundle
+
+To build a shell bundle, we need and older Linux system (we typically use
+CentOS 5.0 for this), as binary images created with older Linux systems
+are generally upwards compatible when installed on newer Linux systems.
+
+A notable exception: We use the OpenSSL package, and we can't tell if
+we need OpenSSL v0.9.8 or OpenSSL v1.0.x. As a result, we have a [special
+process] (OPENSSL.md)  to build both both versions of OpenSSL that we can
+link against.
+
+Once OpenSSL is set up, you need to configure omsagent to include the
+```--enable-ulinux``` qualifier, like this:<br>```./configure --enable-ulinux``` 
+
+### To check out source code repository
+
+To check out the source code repository, you need a command like:
+
+```git clone --recursive git@github.com:MSFTOSSMgmt/bld-omsagent.git```
+
+Note that there are several subprojects, and authentication is a hassle
+unless you set up an SSH key via your github account. We would strongly
+suggest setting up an SSH key with a passphrase, adding the public key
+to your github account, and then add the private key to your SSH program
+to act as an SSH agent. The exact procedure differs based on the SSH
+program that you use, so ask a fellow developer how to set this up if
+you're not sure.
+
+The end result of this mechanism: You specify the password once when you
+start your SSH program, and then you never type the passphrase again.
+
+### To build omsagent
+
+From the bld-omsagent directory (created above from 'git clone', do the
+following:
+
+```
+cd omsagent/build
+./configure
+make
+```
+
+Note that the ```configure``` script takes a variety of options. You can
+use ```configure --help``` to see the options available.
+
+When this completes you should have a native package that you can install
+on your system. The native package should be in a subdirectory off of
+bld-omsagent/omsagent/target (the directory name varies based on debug vs.
+release builds).
+
+As mentioned above, this form a build requires a shell bundle to be installed
+to "seed" your system with other required dependencies.
+
+Note that the build will build multiple versions of Ruby (one for unit test,
+only built once, even after "make distclean"), and then one or two versions
+depending if you're building for a shell bundle or not. Bottom line: The
+first build is always slower than subsequent builds.


### PR DESCRIPTION
@MSFTOSSMgmt/omsdevs 

New files to describe how to build omsagent package (README.md) and OpenSSL (OPENSSL.md).

The build instructions for CentOS 7.x and Ubuntu 14.04 were tested by installing minimal installations of those distributions, creating a checkpoint, and experimentation. After I believed I had the proper configuration commands, I restored the checkpoints, configured, and verified that our software still built.