### PR TITLE
Update to suggest use of 'git rebase' rather than 'git merge'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,15 @@
 - From the develop branch, create a feature branch where you will add your contribution.<br>
   By convention, for feature branch names, we use the format ```<username>-<feature_name>```<br>
   ```git checkout -b <branch-name>```
+- Use of 'git rebase' is suggested to keep feature branches up to date. This works
+  much better if you issue the following configuration changes to git's global configuration:
+```
+ git config --global rerere.enabled true
+ git config --global rerere.autoUpdate true
+```
+ See [rerere documentaiton] (https://git-scm.com/docs/git-rerere) and
+ [rebasing documentation] (https://www.git-scm.com/book/en/v2/Git-Branching-Rebasing)
+ for further details.
 
 ### Code
 - Make the changes as needed, test them out
@@ -17,7 +26,10 @@
 - Push the changes to the server:<br>```git push```
 
 ### Review
-- On [github](https://github.com/MSFTOSSMgmt/bld-omsagent), create a new pull request. That page should only show your changes. Be sure there is a relevant subject for the pull request. In the details, include the line "@MSFTOSSMgmt/omsdevs" and any other comments relevant for the reviewers.
+- On [github](https://github.com/MSFTOSSMgmt/bld-omsagent), create a new pull request.
+That page should only show your changes. Be sure there is a relevant subject for the
+pull request. In the details, include the line "@MSFTOSSMgmt/omsdevs" and any other
+comments relevant for the reviewers.
 - If you need to make new changes based on review, you can just update your branch with further commits and ask for additional reviews.
 - Reviewers can sign off by leaving a comment on the *conversation* tab of the pull request.
 
@@ -32,7 +44,7 @@ changes. Instead, we recommend use of the command line.
 git checkout develop
 git pull
 git checkout <branch-name>
-git merge develop
+git rebase develop
 ```
 <br>Resolve any merge conflicts that may be necessary. If changes are necessary,
 be certain to commit them to your feature branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,6 @@
 ### Setup
 - Fork the repository recursively to get the submodules:<br>```git clone --recursive git@github.com:MSFTOSSMgmt/bld-omsagent.git```
 - If you are contributing in a submodule (dsc, omi, omsagent, opsmgr, pal) chekout the *develop* branch since it is where active development is being made:<br>```git fetch; git checkout develop```
-- From the develop branch, create a feature branch where you will add your contribution.<br>
-  By convention, for feature branch names, we use the format ```<username>-<feature_name>```<br>
-  ```git checkout -b <branch-name>```
 - Use of 'git rebase' is suggested to keep feature branches up to date. This works
   much better if you issue the following configuration changes to git's global configuration:
 ```
@@ -15,6 +12,9 @@
  See [rerere documentaiton] (https://git-scm.com/docs/git-rerere) and
  [rebasing documentation] (https://www.git-scm.com/book/en/v2/Git-Branching-Rebasing)
  for further details.
+- From the develop branch, create a feature branch where you will add your contribution.<br>
+  By convention, for feature branch names, we use the format ```<username>-<feature_name>```<br>
+  ```git checkout -b <branch-name>```
 
 ### Code
 - Make the changes as needed, test them out

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 ### Setup
 - Fork the repository recursively to get the submodules:<br>```git clone --recursive git@github.com:MSFTOSSMgmt/bld-omsagent.git```
 - If you are contributing in a submodule (dsc, omi, omsagent, opsmgr, pal) chekout the *develop* branch since it is where active development is being made:<br>```git fetch; git checkout develop```
-- Use of 'git rebase' is suggested to keep feature branches up to date. This works
-  much better if you issue the following configuration changes to git's global configuration:
+- Use of 'git rebase' is suggested to keep feature branches up to date. To make 'git rebase'
+  easier to use, utilize the 'rerere' feature of git. For details on this
+  feature, see [rerere documentaiton] (https://git-scm.com/docs/git-rerere) and
+  [rebasing documentation] (https://www.git-scm.com/book/en/v2/Git-Branching-Rebasing).
+  Issue the following commands to set up the 'rerere' feature in git's global configuration:
 ```
  git config --global rerere.enabled true
  git config --global rerere.autoUpdate true
 ```
- See [rerere documentaiton] (https://git-scm.com/docs/git-rerere) and
- [rebasing documentation] (https://www.git-scm.com/book/en/v2/Git-Branching-Rebasing)
- for further details.
 - From the develop branch, create a feature branch where you will add your contribution.<br>
   By convention, for feature branch names, we use the format ```<username>-<feature_name>```<br>
   ```git checkout -b <branch-name>```


### PR DESCRIPTION
@MSFTOSSMgmt/omsdevs 

Use of 'git rebase' to update a feature branch creates nicer logs and creates logs that can be squished down if desired. Use of 'git merge' can create problems where this is no longer possible.

Thus, suggest use of 'git rebase' along with git's 'rerere' feature, with documentation pointers for each.

Tested the mechanism on this very feature branch (since last night's build forced updates the the main branch). Worked great! With the 'git rebase' command, the current logs look like this:

* bb72724 (HEAD, origin/jeff-ufeature, jeff-ufeature) Fix indentation issue
* cf57d2b Reorder for clarity
* 672a011 Use 'git rebase' rather than 'git merge' for feature branch updates
* a180041 (origin/master, origin/HEAD, master) Update submodules and version for daily build

In terms of a actual dates, a180041 was made after bb72724.  Due to 'rebase', applied bb72724, cf57d2b, and 672a011 on top of a180041. This will allow a FF merge to the master branch, no "true" merge, and nice clear logs of what was changed.